### PR TITLE
Fix CPU reporting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,18 @@
 module github.com/ubuntu/ubuntu-report
 
 require (
-	github.com/cpuguy83/go-md2man v1.0.10 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.8.2-0.20210422133436-b50299cfaaa1
 	github.com/spf13/cobra v0.0.3
+)
+
+require (
+	github.com/cpuguy83/go-md2man v1.0.10 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
+	golang.org/x/sys v0.0.0-20210218155724-8ebf48af031b // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 
-go 1.13
+go 1.23

--- a/internal/metrics/binmocks_test.go
+++ b/internal/metrics/binmocks_test.go
@@ -81,31 +81,127 @@ func TestMetricsHelperProcess(*testing.T) {
 		}
 		regularOutput := `{
    "lscpu": [
-      {"field": "Architecture:", "data": "x86_64"},
-      {"field": "CPU op-mode(s):", "data": "32-bit, 64-bit"},
-      {"field": "Byte Order:", "data": "Little Endian"},
-      {"field": "CPU(s):", "data": "8"},
-      {"field": "On-line CPU(s) list:", "data": "0-7"},
-      {"field": "Thread(s) per core:", "data": "2"},
-      {"field": "Core(s) per socket:", "data": "4"},
-      {"field": "Socket(s):", "data": "1"},
-      {"field": "NUMA node(s):", "data": "1"},
-      {"field": "Vendor ID:", "data": "Genuine"},
-      {"field": "CPU family:", "data": "6"},
-      {"field": "Model:", "data": "158"},
-      {"field": "Model name:", "data": "Intuis Corus i5-8300H CPU @ 2.30GHz"},
-      {"field": "Stepping:", "data": "10"},
-      {"field": "CPU MHz:", "data": "3419.835"},
-      {"field": "CPU max MHz:", "data": "4000.0000"},
-      {"field": "CPU min MHz:", "data": "800.0000"},
-      {"field": "BogoMIPS:", "data": "4608.00"},
-      {"field": "Virtualization:", "data": "VT-x"},
-      {"field": "L1d cache:", "data": "32K"},
-      {"field": "L1i cache:", "data": "32K"},
-      {"field": "L2 cache:", "data": "256K"},
-      {"field": "L3 cache:", "data": "8192K"},
-      {"field": "NUMA node0 CPU(s):", "data": "0-7"},
-      {"field": "Flags:", "data": "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp"}
+      {
+         "field": "Architecture:",
+         "data": "x86_64",
+         "children": [
+            {
+               "field": "CPU op-mode(s):",
+               "data": "32-bit, 64-bit"
+            },{
+               "field": "Address sizes:",
+               "data": "48 bits physical, 48 bits virtual"
+            },{
+               "field": "Byte Order:",
+               "data": "Little Endian"
+            }
+         ]
+      },{
+         "field": "CPU(s):",
+         "data": "8",
+         "children": [
+            {
+               "field": "On-line CPU(s) list:",
+               "data": "0-15"
+            }
+         ]
+      },{
+         "field": "Vendor ID:",
+         "data": "Genuine",
+         "children": [
+            {
+               "field": "Model name:",
+               "data": "Intuis Corus i5-8300H CPU @ 2.30GHz",
+               "children": [
+                  {
+                     "field": "CPU family:",
+                     "data": "6"
+                  },{
+                     "field": "Model:",
+                     "data": "158"
+                  },{
+                     "field": "Thread(s) per core:",
+                     "data": "2"
+                  },{
+                     "field": "Core(s) per socket:",
+                     "data": "4"
+                  },{
+                     "field": "Socket(s):",
+                     "data": "1"
+                  },{
+                     "field": "Stepping:",
+                     "data": "10"
+                  },{
+                     "field": "CPU(s) scaling MHz:",
+                     "data": "49%"
+                  },{
+                     "field": "CPU max MHz:",
+                     "data": "5000.0000"
+                  },{
+                     "field": "CPU min MHz:",
+                     "data": "200.0000"
+                  },{
+                     "field": "BogoMIPS:",
+                     "data": "123456.78"
+                  },{
+                     "field": "Flags:",
+                     "data": "fpu vme de"
+                  }
+               ]
+            }
+         ]
+      },{
+         "field": "Virtualization features:",
+         "data": null,
+         "children": [
+            {
+               "field": "Virtualization:",
+               "data": "VT-x"
+            }
+         ]
+      },{
+         "field": "Caches (sum of all):",
+         "data": null,
+         "children": [
+            {
+               "field": "L1d:",
+               "data": "256 KiB (8 instances)"
+            },{
+               "field": "L1i:",
+               "data": "256 KiB (8 instances)"
+            },{
+               "field": "L2:",
+               "data": "4 MiB (8 instances)"
+            },{
+               "field": "L3:",
+               "data": "16 MiB (1 instance)"
+            }
+         ]
+      },{
+         "field": "NUMA:",
+         "data": null,
+         "children": [
+            {
+               "field": "NUMA node(s):",
+               "data": "1"
+            },{
+               "field": "NUMA node0 CPU(s):",
+               "data": "0-15"
+            }
+         ]
+      },{
+         "field": "Vulnerabilities:",
+         "data": null,
+         "children": [
+            {
+               "field": "Gather data sampling:",
+               "data": "Not affected"
+            },{
+               "field": "Itlb multihit:",
+               "data": "Not affected"
+            }
+         ]
+      }
    ]
 }`
 		switch args[1] {
@@ -116,9 +212,19 @@ func TestMetricsHelperProcess(*testing.T) {
 		case "missing one optional field":
 			fmt.Println(strings.Replace(regularOutput, "Virtualization vendor:", "", -1))
 		case "virtualized":
-			fmt.Println(regularOutput)
-			fmt.Println(`{"field": "Hypervisor vendor:", "data": "KVM"},
-				{"field": "Virtualization type:", "data": "full"},`)
+			fmt.Println(strings.Replace(regularOutput, `}
+   ]
+}`, `},
+        {
+            "field": "Hypervisor vendor:",
+            "data": "KVM"
+        },
+        {
+            "field": "Virtualization type:",
+            "data": "full"
+        }
+    ]
+}`, -1))
 		case "without space":
 			fmt.Println(`{
    "lscpu": [

--- a/internal/metrics/cmd.go
+++ b/internal/metrics/cmd.go
@@ -35,6 +35,45 @@ func (m Metrics) getGPU() []gpuInfo {
 	return gpus
 }
 
+// helper recursive function for getCPU to populate the cpuInfo struct
+func populateCpuInfo(entries []LscpuEntry, c *cpuInfo) cpuInfo {
+	for _, entry := range entries {
+		switch entry.Field {
+		case "CPU op-mode(s):":
+			c.OpMode = entry.Data
+		case "CPU(s):":
+			c.CPUs = entry.Data
+		case "Thread(s) per core:":
+			c.Threads = entry.Data
+		case "Core(s) per socket:":
+			c.Cores = entry.Data
+		case "Socket(s):":
+			c.Sockets = entry.Data
+		case "Vendor ID:":
+			c.Vendor = entry.Data
+		case "CPU family:":
+			c.Family = entry.Data
+		case "Model:":
+			c.Model = entry.Data
+		case "Stepping:":
+			c.Stepping = entry.Data
+		case "Model name:":
+			c.Name = entry.Data
+		case "Virtualization:":
+			c.Virtualization = entry.Data
+		case "Hypervisor vendor:":
+			c.Hypervisor = entry.Data
+		case "Virtualization type:":
+			c.VirtualizationType = entry.Data
+		}
+		if len(entry.Children) > 0 {
+			populateCpuInfo(entry.Children, c)
+		}
+	}
+
+	return *c
+}
+
 func (m Metrics) getCPU() cpuInfo {
 	c := cpuInfo{}
 
@@ -50,46 +89,6 @@ func (m Metrics) getCPU() cpuInfo {
 	lscpu, ok := result.(*Lscpu)
 	if !ok {
 		log.Infof("Couldn't get CPU info, could not convert to a valid Lscpu struct: %v", result)
-	}
-
-	// helper recursive function to populate the cpuInfo struct
-	var populateCpuInfo func(entries []LscpuEntry, c *cpuInfo) cpuInfo
-	populateCpuInfo = func(entries []LscpuEntry, c *cpuInfo) cpuInfo {
-		for _, entry := range entries {
-			switch entry.Field {
-			case "CPU op-mode(s):":
-				c.OpMode = entry.Data
-			case "CPU(s):":
-				c.CPUs = entry.Data
-			case "Thread(s) per core:":
-				c.Threads = entry.Data
-			case "Core(s) per socket:":
-				c.Cores = entry.Data
-			case "Socket(s):":
-				c.Sockets = entry.Data
-			case "Vendor ID:":
-				c.Vendor = entry.Data
-			case "CPU family:":
-				c.Family = entry.Data
-			case "Model:":
-				c.Model = entry.Data
-			case "Stepping:":
-				c.Stepping = entry.Data
-			case "Model name:":
-				c.Name = entry.Data
-			case "Virtualization:":
-				c.Virtualization = entry.Data
-			case "Hypervisor vendor:":
-				c.Hypervisor = entry.Data
-			case "Virtualization type:":
-				c.VirtualizationType = entry.Data
-			}
-			if len(entry.Children) > 0 {
-				populateCpuInfo(entry.Children, c)
-			}
-		}
-
-		return *c
 	}
 
 	return populateCpuInfo(lscpu.Lscpu, &c)

--- a/internal/metrics/cmd.go
+++ b/internal/metrics/cmd.go
@@ -47,7 +47,10 @@ func (m Metrics) getCPU() cpuInfo {
 		return cpuInfo{}
 	}
 
-	lscpu := result.(*Lscpu)
+	lscpu, ok := result.(*Lscpu)
+	if !ok {
+		log.Infof("Couldn't get CPU info, could not convert to a valid Lscpu struct: %v", result)
+	}
 
 	// helper recursive function to populate the cpuInfo struct
 	var populateCpuInfo func(entries []LscpuEntry, c *cpuInfo) cpuInfo

--- a/internal/metrics/cmd.go
+++ b/internal/metrics/cmd.go
@@ -40,45 +40,56 @@ func (m Metrics) getCPU() cpuInfo {
 
 	r := runCmd(m.cpuInfoCmd)
 
-	for result := range filter(r, `{"field": *"(.*)", *"data": *"(.*)"},`, true) {
-		if result.err != nil {
-			log.Infof("Couldn't get CPU info: "+utils.ErrFormat, result.err)
-			return cpuInfo{}
-		}
+	result, err := parseJSON(r, &Lscpu{})
 
-		key, v := result.r[0], result.r[1]
-
-		switch strings.TrimSpace(key) {
-		case "CPU op-mode(s):":
-			c.OpMode = v
-		case "CPU(s):":
-			c.CPUs = v
-		case "Thread(s) per core:":
-			c.Threads = v
-		case "Core(s) per socket:":
-			c.Cores = v
-		case "Socket(s):":
-			c.Sockets = v
-		case "Vendor ID:":
-			c.Vendor = v
-		case "CPU family:":
-			c.Family = v
-		case "Model:":
-			c.Model = v
-		case "Stepping:":
-			c.Stepping = v
-		case "Model name:":
-			c.Name = v
-		case "Virtualization:":
-			c.Virtualization = v
-		case "Hypervisor vendor:":
-			c.Hypervisor = v
-		case "Virtualization type:":
-			c.VirtualizationType = v
-		}
+	if err != nil {
+		log.Infof("Couldn't get CPU info: "+utils.ErrFormat, err)
+		return cpuInfo{}
 	}
 
-	return c
+	lscpu := result.(*Lscpu)
+
+	// helper recursive function to populate the cpuInfo struct
+	var populateCpuInfo func(entries []LscpuEntry, c *cpuInfo) cpuInfo
+	populateCpuInfo = func(entries []LscpuEntry, c *cpuInfo) cpuInfo {
+		for _, entry := range entries {
+			switch entry.Field {
+			case "CPU op-mode(s):":
+				c.OpMode = entry.Data
+			case "CPU(s):":
+				c.CPUs = entry.Data
+			case "Thread(s) per core:":
+				c.Threads = entry.Data
+			case "Core(s) per socket:":
+				c.Cores = entry.Data
+			case "Socket(s):":
+				c.Sockets = entry.Data
+			case "Vendor ID:":
+				c.Vendor = entry.Data
+			case "CPU family:":
+				c.Family = entry.Data
+			case "Model:":
+				c.Model = entry.Data
+			case "Stepping:":
+				c.Stepping = entry.Data
+			case "Model name:":
+				c.Name = entry.Data
+			case "Virtualization:":
+				c.Virtualization = entry.Data
+			case "Hypervisor vendor:":
+				c.Hypervisor = entry.Data
+			case "Virtualization type:":
+				c.VirtualizationType = entry.Data
+			}
+			if len(entry.Children) > 0 {
+				populateCpuInfo(entry.Children, c)
+			}
+		}
+
+		return *c
+	}
+
+	return populateCpuInfo(lscpu.Lscpu, &c)
 }
 
 func (m Metrics) getScreens() []screenInfo {

--- a/internal/metrics/cmd.go
+++ b/internal/metrics/cmd.go
@@ -35,7 +35,7 @@ func (m Metrics) getGPU() []gpuInfo {
 	return gpus
 }
 
-// helper recursive function for getCPU to populate the cpuInfo struct
+// populateCpuInfo is a helper recursive function for getCPU to populate the cpuInfo struct.
 func populateCpuInfo(entries []LscpuEntry, c *cpuInfo) cpuInfo {
 	for _, entry := range entries {
 		switch entry.Field {

--- a/internal/metrics/json.go
+++ b/internal/metrics/json.go
@@ -17,7 +17,7 @@ type Lscpu struct {
 	Lscpu []LscpuEntry `json:"lscpu"`
 }
 
-func parseJSON(r io.Reader, v interface{}) (interface{}, error) {
+func parseJSON(r io.Reader, v any) (any, error) {
 	// Read the entire content of the io.Reader first to check for errors even if valid json is first
 	buf, err := io.ReadAll(r)
 	if err != nil {

--- a/internal/metrics/json.go
+++ b/internal/metrics/json.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+type LscpuEntry struct {
+	Field    string       `json:"field"`
+	Data     string       `json:"data"`
+	Children []LscpuEntry `json:"children,omitempty"`
+}
+
+type Lscpu struct {
+	Lscpu []LscpuEntry `json:"lscpu"`
+}
+
+func parseJSON(r io.Reader, structPtr interface{}) (interface{}, error) {
+	// Read the entire content of the io.Reader first to check for errors even if valid json is first
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		return nil, errors.Errorf("error reading from io.Reader: %v", err)
+	}
+
+	err = json.Unmarshal(buf, structPtr)
+	if err != nil {
+		return nil, errors.Errorf("couldn't parse JSON: %v", err)
+	}
+	return structPtr, nil
+}

--- a/internal/metrics/json.go
+++ b/internal/metrics/json.go
@@ -17,16 +17,16 @@ type Lscpu struct {
 	Lscpu []LscpuEntry `json:"lscpu"`
 }
 
-func parseJSON(r io.Reader, structPtr interface{}) (interface{}, error) {
+func parseJSON(r io.Reader, v interface{}) (interface{}, error) {
 	// Read the entire content of the io.Reader first to check for errors even if valid json is first
 	buf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Errorf("error reading from io.Reader: %v", err)
 	}
 
-	err = json.Unmarshal(buf, structPtr)
+	err = json.Unmarshal(buf, v)
 	if err != nil {
 		return nil, errors.Errorf("couldn't parse JSON: %v", err)
 	}
-	return structPtr, nil
+	return v, nil
 }


### PR DESCRIPTION
Closes #68 

Fixes CPU reporting by implementing proper JSON parsing and implementing it for lscpu -J. 
Tests have been updated to now better reflect `lscpu -J'`s output (Whitespace, new lines, and children)

For other things that could also be in JSON format, it should be fairly easy to add onto json.go with the expected structure and use `parseJson`

parseJSON uses marshalling instead of a decoder to handle the case where the command provides a valid JSON output, but fails right after.